### PR TITLE
ci: bump to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   build-kicad-full:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       matrix:
@@ -57,7 +57,7 @@ jobs:
           docker push "loozhengyuan/kicad:${{ matrix.version }}-full"
 
   build-verdaccio-unsafe:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     strategy:
       matrix:

--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   automerge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'loozhengyuan' }}
 


### PR DESCRIPTION
This commit updates the repositories to use `ubuntu-24.04` runner type.

Idempotency-Key: 7f2b5c00bd0c4641fed60e25d1d2b7d50bfb867dcbfe7d7e0135a0da89579ffa
